### PR TITLE
Add furry convention registration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Furry Convention Registration System
+
+This is a simple registration system for a furry convention built with Flask. It allows users to register with email or Telegram, edit their profile, and administrators to manage registrations.
+
+## Features
+- Email registration and login
+- Telegram login via the Telegram Login Widget
+- User profile with photo upload
+- Admin dashboard with user statistics and management
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables as needed:
+   - `SECRET_KEY` – secret key for Flask
+   - `TELEGRAM_BOT_TOKEN` – token of your Telegram bot for login verification
+   - `DATABASE_URL` – SQLAlchemy database URI (default uses SQLite `reg.db`)
+3. Run the application:
+   ```bash
+   python run.py
+   ```
+4. Open `http://localhost:5000` in your browser.
+
+To enable Telegram login, replace `YOUR_BOT_USERNAME` in `app/templates/login.html` with your bot's username and set `TELEGRAM_BOT_TOKEN` environment variable.
+
+Uploaded profile photos are stored in the folder specified by `UPLOAD_FOLDER` (default `uploads/`).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,28 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from flask_migrate import Migrate
+
+from .config import Config
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+login_manager.login_view = 'login'
+
+migrate = Migrate()
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+    login_manager.init_app(app)
+
+    with app.app_context():
+        from . import views, admin
+        app.register_blueprint(views.bp)
+        app.register_blueprint(admin.admin_bp)
+        db.create_all()
+
+    return app

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,0 +1,29 @@
+from collections import Counter
+from flask import Blueprint, render_template, redirect, url_for, flash
+from flask_login import login_required, current_user
+
+from .models import User
+from . import db
+
+admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
+
+@admin_bp.before_request
+@login_required
+def restrict_to_admins():
+    if not current_user.is_admin:
+        flash('Admins only')
+        return redirect(url_for('main.home'))
+
+@admin_bp.route('/')
+def dashboard():
+    users = User.query.all()
+    species_count = Counter(user.species for user in users if user.species)
+    return render_template('admin.html', users=users, species_count=species_count)
+
+@admin_bp.route('/delete/<int:user_id>')
+def delete_user(user_id):
+    user = User.query.get_or_404(user_id)
+    db.session.delete(user)
+    db.session.commit()
+    flash('User deleted')
+    return redirect(url_for('admin.dashboard'))

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,23 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, TextAreaField, BooleanField, FileField
+from wtforms.validators import DataRequired, Email, EqualTo
+
+class RegistrationForm(FlaskForm):
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    name = StringField('Name', validators=[DataRequired()])
+    species = StringField('Species')
+    bio = TextAreaField('Bio')
+    password = PasswordField('Password', validators=[DataRequired(), EqualTo('confirm', message='Passwords must match')])
+    confirm = PasswordField('Confirm Password', validators=[DataRequired()])
+    photo = FileField('Profile Photo')
+
+class LoginForm(FlaskForm):
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    remember = BooleanField('Remember Me')
+
+class EditProfileForm(FlaskForm):
+    name = StringField('Name', validators=[DataRequired()])
+    species = StringField('Species')
+    bio = TextAreaField('Bio')
+    photo = FileField('Profile Photo')

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask_login import UserMixin
+
+from . import db, login_manager
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True)
+    password_hash = db.Column(db.String(128))
+    telegram_id = db.Column(db.String(64), unique=True)
+    name = db.Column(db.String(120))
+    species = db.Column(db.String(80))
+    bio = db.Column(db.Text)
+    photo = db.Column(db.String(200))
+    is_admin = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+nav a { margin-right: 10px; }
+.container { max-width: 800px; margin: auto; }
+.flashes { list-style: none; padding: 0; color: red; }

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Admin Dashboard</h2>
+<h3>User Statistics</h3>
+<ul>
+{% for species, count in species_count.items() %}
+    <li>{{ species }}: {{ count }}</li>
+{% endfor %}
+</ul>
+<h3>All Users</h3>
+<table border="1">
+<tr><th>ID</th><th>Email</th><th>Name</th><th>Species</th><th>Actions</th></tr>
+{% for user in users %}
+<tr>
+    <td>{{ user.id }}</td>
+    <td>{{ user.email }}</td>
+    <td>{{ user.name }}</td>
+    <td>{{ user.species }}</td>
+    <td>
+        <a href="{{ url_for('admin.delete_user', user_id=user.id) }}">Delete</a>
+    </td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+    <title>Furry Con Registration</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<nav>
+    {% if current_user.is_authenticated %}
+        <a href="{{ url_for('main.home') }}">Home</a>
+        <a href="{{ url_for('main.edit_profile') }}">Edit Profile</a>
+        {% if current_user.is_admin %}
+            <a href="{{ url_for('admin.dashboard') }}">Admin</a>
+        {% endif %}
+        <a href="{{ url_for('main.logout') }}">Logout</a>
+    {% else %}
+        <a href="{{ url_for('main.login') }}">Login</a>
+        <a href="{{ url_for('main.register') }}">Register</a>
+    {% endif %}
+</nav>
+<div class="container">
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul class="flashes">
+        {% for message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/edit_profile.html
+++ b/app/templates/edit_profile.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Edit Profile</h2>
+<form method="post" enctype="multipart/form-data">
+    {{ form.hidden_tag() }}
+    <p>{{ form.name.label }} {{ form.name(size=32) }}</p>
+    <p>{{ form.species.label }} {{ form.species(size=32) }}</p>
+    <p>{{ form.bio.label }} {{ form.bio(rows=4, cols=40) }}</p>
+    <p>{{ form.photo.label }} {{ form.photo() }}</p>
+    <p><input type="submit" value="Update"></p>
+</form>
+{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Welcome, {{ current_user.name or current_user.email }}</h2>
+{% if current_user.photo %}
+<img src="{{ url_for('main.uploaded_file', filename=current_user.photo) }}" width="200" />
+{% endif %}
+<ul>
+    <li>Email: {{ current_user.email }}</li>
+    <li>Name: {{ current_user.name }}</li>
+    <li>Species: {{ current_user.species }}</li>
+    <li>Bio: {{ current_user.bio }}</li>
+</ul>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+    {{ form.hidden_tag() }}
+    <p>{{ form.email.label }} {{ form.email(size=32) }}</p>
+    <p>{{ form.password.label }} {{ form.password(size=32) }}</p>
+    <p>{{ form.remember() }} {{ form.remember.label }}</p>
+    <p><input type="submit" value="Login"></p>
+</form>
+<p>Or login with Telegram:</p>
+<script async src="https://telegram.org/js/telegram-widget.js?15" data-telegram-login="YOUR_BOT_USERNAME" data-size="large" data-userpic="false" data-auth-url="{{ url_for('main.telegram_login', _external=True) }}" data-request-access="write"></script>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register</h2>
+<form method="post" enctype="multipart/form-data">
+    {{ form.hidden_tag() }}
+    <p>{{ form.email.label }} {{ form.email(size=32) }}</p>
+    <p>{{ form.name.label }} {{ form.name(size=32) }}</p>
+    <p>{{ form.species.label }} {{ form.species(size=32) }}</p>
+    <p>{{ form.bio.label }} {{ form.bio(rows=4, cols=40) }}</p>
+    <p>{{ form.password.label }} {{ form.password(size=32) }}</p>
+    <p>{{ form.confirm.label }} {{ form.confirm(size=32) }}</p>
+    <p>{{ form.photo.label }} {{ form.photo() }}</p>
+    <p><input type="submit" value="Register"></p>
+</form>
+{% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -1,0 +1,119 @@
+import os
+import hmac
+import hashlib
+from urllib.parse import urlencode
+
+from flask import Blueprint, render_template, redirect, url_for, flash, request, send_from_directory
+from flask_login import login_user, logout_user, login_required, current_user
+from werkzeug.utils import secure_filename
+
+from . import db
+from .models import User
+from .forms import RegistrationForm, LoginForm, EditProfileForm
+from .config import Config
+
+bp = Blueprint('main', __name__)
+
+@bp.route('/')
+def index():
+    if current_user.is_authenticated:
+        return redirect(url_for('main.home'))
+    return redirect(url_for('main.login'))
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(email=form.email.data).first()
+        if user and user.check_password(form.password.data):
+            login_user(user, remember=form.remember.data)
+            return redirect(url_for('main.home'))
+        flash('Invalid credentials')
+    return render_template('login.html', form=form)
+
+@bp.route('/telegram_login')
+def telegram_login():
+    data = request.args.to_dict()
+    if verify_telegram_login(data):
+        telegram_id = data.get('id')
+        user = User.query.filter_by(telegram_id=telegram_id).first()
+        if not user:
+            user = User(telegram_id=telegram_id,
+                        name=data.get('first_name'),
+                        email=f"{data.get('username')}@telegram")
+            db.session.add(user)
+            db.session.commit()
+        login_user(user)
+        return redirect(url_for('main.home'))
+    flash('Telegram login failed')
+    return redirect(url_for('main.login'))
+
+@bp.route('/register', methods=['GET', 'POST'])
+def register():
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        if User.query.filter_by(email=form.email.data).first():
+            flash('Email already registered')
+            return redirect(url_for('main.register'))
+        user = User(email=form.email.data, name=form.name.data, species=form.species.data, bio=form.bio.data)
+        user.set_password(form.password.data)
+        if form.photo.data:
+            filename = save_photo(form.photo.data)
+            user.photo = filename
+        db.session.add(user)
+        db.session.commit()
+        login_user(user)
+        return redirect(url_for('main.home'))
+    return render_template('register.html', form=form)
+
+@bp.route('/home')
+@login_required
+def home():
+    return render_template('home.html')
+
+@bp.route('/uploads/<filename>')
+def uploaded_file(filename):
+    return send_from_directory(Config.UPLOAD_FOLDER, filename)
+
+@bp.route('/edit', methods=['GET', 'POST'])
+@login_required
+def edit_profile():
+    form = EditProfileForm(obj=current_user)
+    if form.validate_on_submit():
+        current_user.name = form.name.data
+        current_user.species = form.species.data
+        current_user.bio = form.bio.data
+        if form.photo.data:
+            filename = save_photo(form.photo.data)
+            current_user.photo = filename
+        db.session.commit()
+        flash('Profile updated')
+        return redirect(url_for('main.home'))
+    return render_template('edit_profile.html', form=form)
+
+@bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('main.login'))
+
+
+def verify_telegram_login(data: dict) -> bool:
+    token = Config.TELEGRAM_BOT_TOKEN
+    if not token:
+        return False
+    received_hash = data.pop('hash', None)
+    if not received_hash:
+        return False
+    check_string = '\n'.join(f"{k}={v}" for k, v in sorted(data.items()))
+    secret_key = hashlib.sha256(token.encode()).digest()
+    h = hmac.new(secret_key, msg=check_string.encode(), digestmod=hashlib.sha256)
+    return h.hexdigest() == received_hash
+
+def save_photo(file_storage):
+    if not os.path.exists(Config.UPLOAD_FOLDER):
+        os.makedirs(Config.UPLOAD_FOLDER)
+    filename = secure_filename(file_storage.filename)
+    path = os.path.join(Config.UPLOAD_FOLDER, filename)
+    file_storage.save(path)
+    return filename

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///reg.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', 'uploads')
+    TELEGRAM_BOT_TOKEN = os.environ.get('TELEGRAM_BOT_TOKEN', '')

--- a/readme
+++ b/readme
@@ -1,7 +1,0 @@
-echo "# regsystem" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/CrimsonCypher/regsystem.git
-git push -u origin main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+Flask-SQLAlchemy
+Flask-WTF
+Flask-Login
+Flask-Migrate

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- implement Flask app with login, registration, Telegram auth, and admin dashboard
- add templates and static styling
- document setup and usage in README

## Testing
- `python -m py_compile app/*.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_68443a118d588330a7cd2fd7da744782